### PR TITLE
fix(fsa-browser): 🐛 camel case error on linux failing build

### DIFF
--- a/packages/fsa-database/src/index.ts
+++ b/packages/fsa-database/src/index.ts
@@ -73,7 +73,7 @@ import toggleFileTypeHidden from './models/fileTypes/toggleFileTypeHidden'
 import addRootDirectory from './models/rootDirectories/addRootDirectory'
 import createRootDirectory from './models/rootDirectories/createRootDirectory'
 import deleteRootDirectory from './models/rootDirectories/deleteRootDirectoryAndFiles'
-import rescanRootDirectories from './models/rootDirectories/rescanRootDirectories'
+import rescanRootDirectories from './models/rootDirectories/reScanRootDirectories'
 import rootDirHasFilesInCollections from './models/rootDirectories/rootDirHasFilesInCollections'
 import selectRootDirectory from './models/rootDirectories/selectRootDirectory'
 // settings

--- a/packages/fsa-database/src/models/rootDirectories/index.ts
+++ b/packages/fsa-database/src/models/rootDirectories/index.ts
@@ -1,6 +1,6 @@
 import createRootDirectory from './createRootDirectory'
 import deleteRootDirectory from './deleteRootDirectoryAndFiles'
-import rescanRootDirectories from './rescanRootDirectories'
+import rescanRootDirectories from './reScanRootDirectories'
 import rootDirHasFilesInCollections from './rootDirHasFilesInCollections'
 import rootDirectoryAlreadyExists from './rootDirectoryAlreadyExists'
 import addRootDirectory from './addRootDirectory'


### PR DESCRIPTION
fixes imports not being camel cased working on windows but not unix so the build failed.